### PR TITLE
[+] Add slf4j-simple & spacing fix

### DIFF
--- a/WindSpigot-Server/pom.xml
+++ b/WindSpigot-Server/pom.xml
@@ -104,6 +104,12 @@
 			<scope>compile</scope>
 		</dependency>
 
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-simple</artifactId>
+			<version>1.7.36</version>
+		</dependency>
+
 		<!-- testing -->
 		<dependency>
 			<groupId>junit</groupId>

--- a/WindSpigot-Server/src/main/java/org/spigotmc/SpigotConfig.java
+++ b/WindSpigot-Server/src/main/java/org/spigotmc/SpigotConfig.java
@@ -288,7 +288,7 @@ public class SpigotConfig {
 
 	private static void playerSample() {
 		playerSample = getInt("settings.sample-count", 12);
-		System.out.println("Server Ping Player Sample Count: " + playerSample);
+		Bukkit.getLogger().log(Level.INFO, "Server Ping Player Sample Count: " + playerSample);
 	}
 
 	public static int playerShuffle;


### PR DESCRIPTION
slf4j-simple fixes the missing class error on startup and just changed from println to bukkit's logger to fix extra space in console when that was printed