### PR TITLE
Optimize Network Queue (SportPaper-0108)

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ See the patches list below.
 [SportPaper-0201] Cache block break animation packet
 [SportPaper-0203] Fix Teleport Invisibility
 [SportPaper-0204] Optimize toLegacyData removing unneeded sanity checks
+[SportPaper-0108] Optimize Network Queue
 
 [PaperBin-????] WorldServer#everyoneDeeplySleeping optimization
 

--- a/WindSpigot-Server/src/main/java/io/papermc/paper/util/linkedqueue/CachedSizeConcurrentLinkedQueue.java
+++ b/WindSpigot-Server/src/main/java/io/papermc/paper/util/linkedqueue/CachedSizeConcurrentLinkedQueue.java
@@ -1,0 +1,31 @@
+package io.papermc.paper.util.linkedqueue;
+
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.LongAdder;
+
+public class CachedSizeConcurrentLinkedQueue<E> extends ConcurrentLinkedQueue<E> {
+    private final LongAdder cachedSize = new LongAdder();
+
+    @Override
+    public boolean add(E e) {
+        boolean result = super.add(e);
+        if (result) {
+            cachedSize.increment();
+        }
+        return result;
+    }
+
+    @Override
+    public E poll() {
+        E result = super.poll();
+        if (result != null) {
+            cachedSize.decrement();
+        }
+        return result;
+    }
+
+    @Override
+    public int size() {
+        return cachedSize.intValue();
+    }
+}

--- a/WindSpigot-Server/src/main/java/net/minecraft/server/MinecraftServer.java
+++ b/WindSpigot-Server/src/main/java/net/minecraft/server/MinecraftServer.java
@@ -25,6 +25,7 @@ import java.util.function.Function;
 import javax.imageio.ImageIO;
 
 import ga.windpvp.windspigot.random.FastRandom;
+import io.papermc.paper.util.linkedqueue.CachedSizeConcurrentLinkedQueue;
 import org.apache.commons.lang3.Validate;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -122,9 +123,7 @@ public abstract class MinecraftServer extends ReentrantIAsyncHandler<TasksPerTic
 	private long X = 0L;
 	private final GameProfileRepository Y;
 	private final UserCache Z;
-	protected final Queue<FutureTask<?>> j = new java.util.concurrent.ConcurrentLinkedQueue<FutureTask<?>>(); // Spigot,
-																												// PAIL:
-																												// Rename
+	protected final Queue<FutureTask<?>> j = new CachedSizeConcurrentLinkedQueue<>(); // Spigot, PAIL: Rename // Paper - Make size() constant-time
 	private Thread serverThread;
 	private long ab = az();
 


### PR DESCRIPTION
[+] Add CachedSizeConcurrentLinkedQueue from Paper
[~] Change Network Queue in MinecraftServer from ConcurrentLinkedQueue to CachedSizeConcurrentLinkedQueue.
In the Future maybe other Queues can be changed to this for a slight performance increase.