### PR TITLE
feat: replace disconnect.spam toggle with tab spam config (credit to PandaSpigot)

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ See the patches list below.
 [WindSpigot-0015] Configurable explosion animations and sound
 [WindSpigot-0016] Configurable weather changes
 [WindSpigot-0017] Configurable fishing rod speed multiplier
-[WindSpigot-0018] Toggle for disconnect.spam
+
+[PandaSpigot-0115] Break up and make tab spam limits configurable
 
 [Spigot-0097] Remove DataWatcher Locking by spottedleaf
 [Spigot-0138] Branchless NibbleArray by md5

--- a/WindSpigot-Server/src/main/java/com/windpvp/windspigot/config/WindSpigotConfig.java
+++ b/WindSpigot-Server/src/main/java/com/windpvp/windspigot/config/WindSpigotConfig.java
@@ -50,7 +50,7 @@ public class WindSpigotConfig {
 		}
 		config.options().copyDefaults(true);
 
-		int configVersion = 28; // Update this every new configuration update
+		int configVersion = 29; // Update this every new configuration update
 
 		version = getInt("config-version", configVersion);
 		set("config-version", configVersion);
@@ -197,7 +197,8 @@ public class WindSpigotConfig {
 		c.addComment("settings.tcp-fast-open.enabled", "Enables the TCP_FASTOPEN socket option.");
 		c.addComment("settings.tcp-fast-open.mode", "Options: 0 - Disabled.; 1 - TFO is enabled for outgoing connections (clients).; 2 - TFO is enabled for incoming connections (servers).; 3 - TFO is enabled for both clients and servers.");
 		c.addComment("settings.instant-interaction", "Disables delay of all interactions.");
-        c.addComment("settings.disable-disconnect-spam", "Disables that players can be kicked because of disconnect.spam.");
+        c.addComment("settings.disconnect-spam.increment", "How much to add to the tab-spam counter per spam event (each time this check triggers)");
+        c.addComment("settings.disconnect-spam.limit", "Threshold for the running tab-spam counter; once it exceeds this value, the player is disconnected.");
 	}
 
 	private static void set(String path, Object val) {
@@ -635,10 +636,15 @@ public class WindSpigotConfig {
 		instantPlayInUseEntity = getBoolean("settings.instant-interaction", false);
 	}
 	
-    public static boolean disableDisconnectSpam;
-
-    private static void disableDisconnectSpam() {
-        disableDisconnectSpam = getBoolean("settings.disable-disconnect-spam", true);
+	
+	// Credit to uRyanxD and PandaSpigot for this feature
+	public static int tabSpamIncrement;
+	public static int tabSpamLimit;
+	
+    private static void tabSpam() {
+    	// Default is 10 and 500 - made it a bit more lenient
+        tabSpamIncrement = getInt("settings.disconnect-spam.increment", 5);
+        tabSpamLimit = getInt("settings.disconnect-spam.limit", 750);
     }
     
 }

--- a/WindSpigot-Server/src/main/java/net/minecraft/server/PlayerConnection.java
+++ b/WindSpigot-Server/src/main/java/net/minecraft/server/PlayerConnection.java
@@ -84,6 +84,7 @@ public class PlayerConnection implements PacketListenerPlayIn, IUpdatePlayerList
 	private static final AtomicIntegerFieldUpdater<PlayerConnection> chatSpamField = AtomicIntegerFieldUpdater
 			.newUpdater(PlayerConnection.class, "chatThrottle");
 	// CraftBukkit end
+	private final java.util.concurrent.atomic.AtomicInteger tabSpamLimiter = new java.util.concurrent.atomic.AtomicInteger(); // PandaSpigot - Configurable tab spam limits
 	private int m;
 	private final IntHashMap<Short> n = new IntHashMap<>();
 	private double o;
@@ -180,6 +181,7 @@ public class PlayerConnection implements PacketListenerPlayIn, IUpdatePlayerList
 			 */
 			// CraftBukkit end
 		}
+		if (tabSpamLimiter.get() > 0) tabSpamLimiter.getAndDecrement(); // PandaSpigot - Split variable
 
 		if (this.m > 0) {
 			--this.m;
@@ -2379,16 +2381,11 @@ public class PlayerConnection implements PacketListenerPlayIn, IUpdatePlayerList
 	@Override
 	public void a(PacketPlayInTabComplete packetplayintabcomplete) {
 		PlayerConnectionUtils.ensureMainThread(packetplayintabcomplete, this, this.player.u());
-        // WindSpigot start - toggle for disconnecting players for tab complete spam
-		if (!WindSpigotConfig.disableDisconnectSpam) {
-			// CraftBukkit start
-			if (chatSpamField.addAndGet(this, 10) > 500
-					&& !this.minecraftServer.getPlayerList().isOp(this.player.getProfile())) {
-				this.disconnect("disconnect.spam");
-				return;
-			}
-        }
-		// WindSpigot end
+		// CraftBukkit start
+        if (tabSpamLimiter.addAndGet(WindSpigotConfig.tabSpamIncrement) > WindSpigotConfig.tabSpamLimit && !this.minecraftServer.getPlayerList().isOp(this.player.getProfile())) { // PandaSpigot - Split and make configurable
+			this.disconnect("disconnect.spam");
+			return;
+		}        
 		// CraftBukkit end
 		ArrayList arraylist = Lists.newArrayList();
 		Iterator iterator = this.minecraftServer


### PR DESCRIPTION
It's better to use configurable tab spam limits rather than a flat toggle, as that can be exploited.

Credit to uRyanxD from PandaSpigot for the patch!