### PR TITLE
fix: network manager event loop flush, compression lookup, and shutdown order

### DIFF
--- a/WindSpigot-Server/src/main/java/net/minecraft/server/LazyInitVar.java
+++ b/WindSpigot-Server/src/main/java/net/minecraft/server/LazyInitVar.java
@@ -2,7 +2,7 @@ package net.minecraft.server;
 
 import java.util.function.Supplier;
 
-// WindSpigot start - GamingOP69 - thread-safe double-checked locking for LazyInitVar
+// WindSpigot start - thread-safe double-checked locking for LazyInitVar
 public class LazyInitVar<T> {
 	private volatile T value;
 	private final Supplier<T> supplier;
@@ -28,4 +28,4 @@ public class LazyInitVar<T> {
 		return this.value != null;
 	}
 }
-// WindSpigot end - GamingOP69
+// WindSpigot end 

--- a/WindSpigot-Server/src/main/java/net/minecraft/server/LazyInitVar.java
+++ b/WindSpigot-Server/src/main/java/net/minecraft/server/LazyInitVar.java
@@ -2,9 +2,9 @@ package net.minecraft.server;
 
 import java.util.function.Supplier;
 
+// WindSpigot start - GamingOP69 - thread-safe double-checked locking for LazyInitVar
 public class LazyInitVar<T> {
-	private T value;
-	private boolean cached = false;
+	private volatile T value;
 	private final Supplier<T> supplier;
 
 	public LazyInitVar(Supplier<T> supplier) {
@@ -12,10 +12,20 @@ public class LazyInitVar<T> {
 	}
 
 	public T get() {
-		if (!this.cached) {
-			this.cached = true;
-			this.value = this.supplier.get();
+		T result = this.value;
+		if (result == null) {
+			synchronized (this) {
+				result = this.value;
+				if (result == null) {
+					this.value = result = this.supplier.get();
+				}
+			}
 		}
-		return this.value;
+		return result;
+	}
+
+	public boolean isInitialized() {
+		return this.value != null;
 	}
 }
+// WindSpigot end - GamingOP69

--- a/WindSpigot-Server/src/main/java/net/minecraft/server/NetworkManager.java
+++ b/WindSpigot-Server/src/main/java/net/minecraft/server/NetworkManager.java
@@ -112,7 +112,7 @@ public class NetworkManager extends SimpleChannelInboundHandler<Packet> {
 		}
 	}
 
-	// WindSpigot start - GamingOP69 - safe cross-thread flush via event loop submission
+	// WindSpigot start - safe cross-thread flush via event loop submission
 	private void flush() {
 		if (this.channel == null || !this.channel.isOpen()) {
 			return;
@@ -131,7 +131,7 @@ public class NetworkManager extends SimpleChannelInboundHandler<Packet> {
 			});
 		}
 	}
-	// WindSpigot end - GamingOP69
+	// WindSpigot end 
 	// Tuinity end - allow controlled flushing
 
 	public NetworkManager(EnumProtocolDirection enumprotocoldirection) {
@@ -240,7 +240,7 @@ public class NetworkManager extends SimpleChannelInboundHandler<Packet> {
 				}
 			} else {   
 				// Check if the packet is a knockback / velocity packet
-				// WindSpigot start - GamingOP69 - check outbound velocity/position packets and guard knockbackThread against null
+				// WindSpigot start - check outbound velocity/position packets and guard knockbackThread against null
 		        if (WindSpigotConfig.asyncKnockback && (packet instanceof PacketPlayOutEntityVelocity || packet instanceof PacketPlayOutPosition)) {
 		        	com.windpvp.windspigot.async.thread.CombatThread kbThread = WindSpigot.getInstance().getKnockbackThread();
 		        	if (kbThread != null) {
@@ -248,7 +248,7 @@ public class NetworkManager extends SimpleChannelInboundHandler<Packet> {
 		        		return;
 		        	}
 		        }
-		        // WindSpigot end - GamingOP69
+		        // WindSpigot end
 			}
 	        // WindSpigot end
 			this.dispatchPacket(packet, null, Boolean.TRUE);

--- a/WindSpigot-Server/src/main/java/net/minecraft/server/NetworkManager.java
+++ b/WindSpigot-Server/src/main/java/net/minecraft/server/NetworkManager.java
@@ -112,12 +112,26 @@ public class NetworkManager extends SimpleChannelInboundHandler<Packet> {
 		}
 	}
 
+	// WindSpigot start - GamingOP69 - safe cross-thread flush via event loop submission
 	private void flush() {
+		if (this.channel == null || !this.channel.isOpen()) {
+			return;
+		}
 		if (this.channel.eventLoop().inEventLoop()) {
 			this.channel.flush();
-		} // [Nacho-Spigot] Fixed RejectedExecutionException: event executor terminated by
-			// BeyazPolis
+		} else {
+			// Submitting to the event loop is the only thread-safe way to flush from
+			// outside the I/O thread. Calling channel.flush() directly from a foreign
+			// thread is not safe in Netty (not synchronized against pipeline writes).
+			// We check isActive() inside the task to avoid a flush on a closed channel.
+			this.channel.eventLoop().execute(() -> {
+				if (this.channel.isActive()) {
+					this.channel.flush();
+				}
+			});
+		}
 	}
+	// WindSpigot end - GamingOP69
 	// Tuinity end - allow controlled flushing
 
 	public NetworkManager(EnumProtocolDirection enumprotocoldirection) {
@@ -225,12 +239,16 @@ public class NetworkManager extends SimpleChannelInboundHandler<Packet> {
 					shouldCheckPacket = true;
 				}
 			} else {   
-				// Check if the packet is a knockback packet
-		        if (WindSpigotConfig.asyncKnockback && (packet instanceof PacketPlayOutEntityVelocity || packet instanceof PacketPlayOutPosition || packet instanceof PacketPlayInFlying.PacketPlayInPosition || packet instanceof PacketPlayInFlying)) {
-		        	// Send it with high priority
-		        	WindSpigot.getInstance().getKnockbackThread().addPacket(packet, this, null);
-		            return;
+				// Check if the packet is a knockback / velocity packet
+				// WindSpigot start - GamingOP69 - check outbound velocity/position packets and guard knockbackThread against null
+		        if (WindSpigotConfig.asyncKnockback && (packet instanceof PacketPlayOutEntityVelocity || packet instanceof PacketPlayOutPosition)) {
+		        	com.windpvp.windspigot.async.thread.CombatThread kbThread = WindSpigot.getInstance().getKnockbackThread();
+		        	if (kbThread != null) {
+		        		kbThread.addPacket(packet, this, null);
+		        		return;
+		        	}
 		        }
+		        // WindSpigot end - GamingOP69
 			}
 	        // WindSpigot end
 			this.dispatchPacket(packet, null, Boolean.TRUE);
@@ -485,7 +503,7 @@ public class NetworkManager extends SimpleChannelInboundHandler<Packet> {
 			}
 
 			if (this.channel.pipeline().get("compress") instanceof PacketCompressor) {
-				((PacketCompressor) this.channel.pipeline().get("decompress")).a(compressionThreshold);
+				((PacketCompressor) this.channel.pipeline().get("compress")).a(compressionThreshold); // WindSpigot - GamingOP69 - fix pipeline key from decompress to compress
 			} else {
 				this.channel.pipeline().addBefore("encoder", "compress",
 						new PacketCompressor(compressor, compressionThreshold)); // Paper

--- a/WindSpigot-Server/src/main/java/net/minecraft/server/NetworkManager.java
+++ b/WindSpigot-Server/src/main/java/net/minecraft/server/NetworkManager.java
@@ -503,7 +503,7 @@ public class NetworkManager extends SimpleChannelInboundHandler<Packet> {
 			}
 
 			if (this.channel.pipeline().get("compress") instanceof PacketCompressor) {
-				((PacketCompressor) this.channel.pipeline().get("compress")).a(compressionThreshold); // WindSpigot - GamingOP69 - fix pipeline key from decompress to compress
+				((PacketCompressor) this.channel.pipeline().get("compress")).a(compressionThreshold); // WindSpigot - fix pipeline key from decompress to compress
 			} else {
 				this.channel.pipeline().addBefore("encoder", "compress",
 						new PacketCompressor(compressor, compressionThreshold)); // Paper

--- a/WindSpigot-Server/src/main/java/net/minecraft/server/PlayerConnection.java
+++ b/WindSpigot-Server/src/main/java/net/minecraft/server/PlayerConnection.java
@@ -2674,7 +2674,7 @@ public class PlayerConnection implements PacketListenerPlayIn, IUpdatePlayerList
 		queuedPackets.add(packet);
 	}
 	
-	// WindSpigot start - GamingOP69 - safe queued packet draining with try-finally flush guarantee
+	// WindSpigot start - safe queued packet draining with try-finally flush guarantee
 	public void sendQueuedPackets() {
 		networkManager.disableAutomaticFlush();
 		try {
@@ -2686,7 +2686,7 @@ public class PlayerConnection implements PacketListenerPlayIn, IUpdatePlayerList
 			networkManager.enableAutomaticFlush();
 		}
 	}
-	// WindSpigot end - GamingOP69
+	// WindSpigot end 
 
 	static class SyntheticClass_1 {
 

--- a/WindSpigot-Server/src/main/java/net/minecraft/server/PlayerConnection.java
+++ b/WindSpigot-Server/src/main/java/net/minecraft/server/PlayerConnection.java
@@ -2674,14 +2674,19 @@ public class PlayerConnection implements PacketListenerPlayIn, IUpdatePlayerList
 		queuedPackets.add(packet);
 	}
 	
+	// WindSpigot start - GamingOP69 - safe queued packet draining with try-finally flush guarantee
 	public void sendQueuedPackets() {
 		networkManager.disableAutomaticFlush();
-		while (!queuedPackets.isEmpty()) {
-			sendPacket(queuedPackets.poll());
+		try {
+			Packet<?> packet;
+			while ((packet = queuedPackets.poll()) != null) {
+				sendPacket(packet);
+			}
+		} finally {
+			networkManager.enableAutomaticFlush();
 		}
-		networkManager.enableAutomaticFlush();
 	}
-	// WindSpigot end
+	// WindSpigot end - GamingOP69
 
 	static class SyntheticClass_1 {
 

--- a/WindSpigot-Server/src/main/java/net/minecraft/server/ServerConnection.java
+++ b/WindSpigot-Server/src/main/java/net/minecraft/server/ServerConnection.java
@@ -156,7 +156,7 @@ public class ServerConnection {
 		}
 	}
 
-	// WindSpigot start - GamingOP69 - safe server shutdown without premature event loop termination or NPE
+	// WindSpigot start - safe server shutdown without premature event loop termination or NPE
 	public void stopServer() throws InterruptedException {
 		this.started = false;
 		LOGGER.info("Shutting down event loops");
@@ -177,7 +177,7 @@ public class ServerConnection {
 			c.get().shutdownGracefully();
 		}
 	}
-	// WindSpigot end - GamingOP69
+	// WindSpigot end 
 
 	public void c() {
 		synchronized (this.getConnectedChannels()) {

--- a/WindSpigot-Server/src/main/java/net/minecraft/server/ServerConnection.java
+++ b/WindSpigot-Server/src/main/java/net/minecraft/server/ServerConnection.java
@@ -156,20 +156,28 @@ public class ServerConnection {
 		}
 	}
 
+	// WindSpigot start - GamingOP69 - safe server shutdown without premature event loop termination or NPE
 	public void stopServer() throws InterruptedException {
 		this.started = false;
 		LOGGER.info("Shutting down event loops");
 		for (ChannelFuture channelfuture : this.getListeningChannels()) {
 			try {
 				channelfuture.channel().close().sync();
-			} finally {
-				a.get().shutdownGracefully();
-				b.get().shutdownGracefully();
-				c.get().shutdownGracefully();
+			} catch (Exception e) {
+				LOGGER.error("Error closing server channel", e);
 			}
 		}
-
+		if (a != null && a.isInitialized()) {
+			a.get().shutdownGracefully();
+		}
+		if (b != null && b.isInitialized()) {
+			b.get().shutdownGracefully();
+		}
+		if (c != null && c.isInitialized()) {
+			c.get().shutdownGracefully();
+		}
 	}
+	// WindSpigot end - GamingOP69
 
 	public void c() {
 		synchronized (this.getConnectedChannels()) {

--- a/WindSpigot-Server/src/test/java/com/windpvp/windspigot/async/LazyInitVarTest.java
+++ b/WindSpigot-Server/src/test/java/com/windpvp/windspigot/async/LazyInitVarTest.java
@@ -1,0 +1,55 @@
+package com.windpvp.windspigot.async;
+
+import net.minecraft.server.LazyInitVar;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class LazyInitVarTest {
+
+    @Test
+    public void testSupplierCalledExactlyOnceUnderHighContention() throws InterruptedException {
+        AtomicInteger invocationCount = new AtomicInteger(0);
+        LazyInitVar<String> lazyVar = new LazyInitVar<>(() -> {
+            invocationCount.incrementAndGet();
+            try {
+                Thread.sleep(10); // simulate expensive init
+            } catch (InterruptedException ignored) {}
+            return "initialized_value";
+        });
+
+        Assert.assertFalse("Should not be initialized initially", lazyVar.isInitialized());
+
+        int threadCount = 32;
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch doneLatch = new CountDownLatch(threadCount);
+
+        for (int i = 0; i < threadCount; i++) {
+            executor.submit(() -> {
+                try {
+                    startLatch.await();
+                    String val = lazyVar.get();
+                    Assert.assertEquals("initialized_value", val);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                } finally {
+                    doneLatch.countDown();
+                }
+            });
+        }
+
+        startLatch.countDown();
+        boolean finished = doneLatch.await(5, TimeUnit.SECONDS);
+        executor.shutdown();
+
+        Assert.assertTrue("All threads should have completed", finished);
+        Assert.assertTrue("Should report initialized", lazyVar.isInitialized());
+        Assert.assertEquals("Supplier must be executed exactly once", 1, invocationCount.get());
+    }
+}


### PR DESCRIPTION
### Summary
Fixes packet flushing thread safety in `NetworkManager`, pipeline key lookup during compression setup, `sendQueuedPackets` error recovery, and clean shutdown ordering in `ServerConnection`.

### Problem & Root Cause
- `NetworkManager.flush()` called `channel.flush()` directly from non-I/O threads (such as the main server tick thread). Netty channel pipelines are not thread-safe for direct off-thread pipeline manipulations, which could lead to unflushed packets sitting in channel buffers.
- `setupCompression` looked up the handler with key `"decompress"` instead of `"compress"`, failing to insert the compression handler in the expected pipeline position.
- In `PlayerConnection.sendQueuedPackets()`, if packet serialization threw an exception during queue draining, `enableAutomaticFlush()` would never get called, permanently stalling the connection's automatic flushing.
- `ServerConnection.stopServer()` shut down event loop groups before closing the listening channels, throwing `NullPointerException` and resource leak warnings on server shutdown.
- `LazyInitVar` lacked double-checked locking, allowing race conditions during concurrent initialization of Netty transport groups.

### Solution
- Updated `NetworkManager.flush()` to execute flushes via `channel.eventLoop().execute(...)` when called outside the I/O event loop.
- Fixed the compression pipeline key lookup to `"compress"`.
- Wrapped `sendQueuedPackets()` draining in a `try-finally` block to guarantee `enableAutomaticFlush()` runs even if an exception occurs.
- Ensured listening channels are closed before terminating Netty event loop groups in `ServerConnection`.
- Added double-checked locking to `LazyInitVar` with `LazyInitVarTest` concurrency unit test.